### PR TITLE
Add audio playback support for linux and windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Clanki is a terminal-based Anki review client that lets you review your Anki fla
 |---------|-----------|
 | Anki scheduling algorithms | ✅ |
 | Image rendering | ✅ |
-| Audio playback | ✅ (macOS only) |
+| Audio playback | ✅ (macOS/Linux/Windows) |
 | Basic cards | ✅ |
 | Cloze cards | ✅ |
 | Type in the answer | 🚧 (planned)|
@@ -25,6 +25,7 @@ Clanki is a terminal-based Anki review client that lets you review your Anki fla
 - Python 3.10 or later
 - Anki Desktop installed with at least one synced profile
 - Anki Desktop must be **closed** when running clanki
+- For Linux/Windows audio playback: `ffplay` (from FFmpeg) available in `PATH`
 
 ## Installation
 

--- a/clanki/cli.py
+++ b/clanki/cli.py
@@ -5,7 +5,7 @@ This module provides the command-line interface with support for:
 - Plain terminal mode
 - Review mode with deck selection
 - Sync mode
-- Audio playback support (macOS only)
+- Audio playback support (platform-dependent backend)
 """
 
 from __future__ import annotations
@@ -524,7 +524,7 @@ def main(argv: list[str] | None = None) -> int:
     audio_group.add_argument(
         "--audio",
         action="store_true",
-        help="Enable audio playback (overrides config, macOS only)",
+        help="Enable audio playback (overrides config)",
     )
     audio_group.add_argument(
         "--no-audio",
@@ -591,7 +591,7 @@ def main(argv: list[str] | None = None) -> int:
     review_audio_group.add_argument(
         "--audio",
         action="store_true",
-        help="Enable audio playback (overrides config, macOS only)",
+        help="Enable audio playback (overrides config)",
     )
     review_audio_group.add_argument(
         "--no-audio",


### PR DESCRIPTION
## Summary
  - add cross-platform audio backend selection (`afplay` on macOS, `ffplay` on Linux/Windows)
  - make playback interruptible and safer across overlapping requests
  - update CLI/README messaging and expand audio test coverage

  ## Testing
  - uv run pytest tests/test_audio.py
  - uv run pytest tests/integration/test_cli_smoke.py -k audio
  - python3 -m py_compile clanki/audio.py clanki/tui/screens/review.py tests/test_audio.py"

Fixes #3 