### PR TITLE
Fix ffplay -nostdin compatibility with ffmpeg 8.0+

### DIFF
--- a/clanki/audio.py
+++ b/clanki/audio.py
@@ -155,7 +155,7 @@ def _backend_candidates() -> tuple[_AudioBackend, ...]:
     ffplay = _AudioBackend(
         name="ffplay",
         binary="ffplay",
-        base_args=("ffplay", "-nodisp", "-autoexit", "-nostdin", "-loglevel", "quiet"),
+        base_args=("ffplay", "-nodisp", "-autoexit", "-loglevel", "quiet"),
     )
 
     if sys.platform == "darwin":
@@ -320,7 +320,7 @@ def play_audio_files(
                             command,
                             stdin=subprocess.DEVNULL,
                             stdout=subprocess.DEVNULL,
-                            stderr=subprocess.DEVNULL,
+                            stderr=subprocess.PIPE,
                         )
                     except (OSError, subprocess.SubprocessError) as exc:
                         launch_error = exc
@@ -339,10 +339,16 @@ def play_audio_files(
                 try:
                     return_code = proc.wait()
                     if return_code != 0 and not stop_event.is_set():
-                        _emit_on_error(
-                            on_error,
-                            f"Audio playback exited with status {return_code} ({backend.binary})",
-                        )
+                        stderr_text = ""
+                        if proc.stderr is not None:
+                            try:
+                                stderr_text = proc.stderr.read().decode("utf-8", errors="replace").strip()
+                            except Exception:
+                                pass
+                        msg = f"Audio playback exited with status {return_code} ({backend.binary})"
+                        if stderr_text:
+                            msg += f": {stderr_text}"
+                        _emit_on_error(on_error, msg)
                         break
                 finally:
                     with _process_lock:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -325,9 +325,10 @@ class TestPlayAudioFiles:
             command = mock_popen.call_args[0][0]
             kwargs = mock_popen.call_args.kwargs
             assert command[0] == "ffplay"
-            assert "-nostdin" in command
+            assert "-nostdin" not in command
             assert command[-1].endswith("test.mp3")
             assert kwargs["stdin"] is audio_module.subprocess.DEVNULL
+            assert kwargs["stderr"] is audio_module.subprocess.PIPE
 
         reset_audio_cache()
 
@@ -437,6 +438,58 @@ class TestPlayAudioFiles:
             assert audio_module._playback_thread is active_thread_before
             assert audio_module._playback_thread is second_thread
             assert audio_module._playback_stop_event is active_stop_event_before
+
+        reset_audio_cache()
+
+    def test_nonzero_exit_includes_stderr(self, tmp_path):
+        """Non-zero exit should include stderr content in error message."""
+        reset_audio_cache()
+
+        audio_file = tmp_path / "test.mp3"
+        audio_file.touch()
+
+        with (
+            patch("sys.platform", "linux"),
+            patch("shutil.which", side_effect=_which_ffplay_only),
+            patch("clanki.audio.threading.Thread", _ImmediateThread),
+            patch("subprocess.Popen") as mock_popen,
+        ):
+            mock_proc = MagicMock()
+            mock_proc.wait.return_value = 1
+            mock_proc.stderr.read.return_value = b"Option nostdin not found."
+            mock_popen.return_value = mock_proc
+
+            errors: list[str] = []
+            play_audio_files([audio_file], on_error=errors.append)
+            assert len(errors) == 1
+            assert "status 1" in errors[0]
+            assert "Option nostdin not found." in errors[0]
+
+        reset_audio_cache()
+
+    def test_nonzero_exit_empty_stderr(self, tmp_path):
+        """Non-zero exit with empty stderr should give clean message."""
+        reset_audio_cache()
+
+        audio_file = tmp_path / "test.mp3"
+        audio_file.touch()
+
+        with (
+            patch("sys.platform", "linux"),
+            patch("shutil.which", side_effect=_which_ffplay_only),
+            patch("clanki.audio.threading.Thread", _ImmediateThread),
+            patch("subprocess.Popen") as mock_popen,
+        ):
+            mock_proc = MagicMock()
+            mock_proc.wait.return_value = 1
+            mock_proc.stderr.read.return_value = b""
+            mock_popen.return_value = mock_proc
+
+            errors: list[str] = []
+            play_audio_files([audio_file], on_error=errors.append)
+            assert len(errors) == 1
+            assert "status 1" in errors[0]
+            assert errors[0].endswith("(ffplay)")
 
         reset_audio_cache()
 


### PR DESCRIPTION
## Summary
- Remove `-nostdin` from ffplay args — it was dropped in ffmpeg 8.0 and is redundant since `stdin=subprocess.DEVNULL` already prevents stdin reads at the OS level
- Capture stderr on playback failure so error messages include the actual reason (e.g. `"Audio playback exited with status 1 (ffplay): Option nostdin not found."`)
- Add tests for stderr capture on non-zero exit

Fixes #3 (audio playback failure on ffmpeg 8.0.1 reported by @teto)