### PR TITLE
Improve ergonomics on smaller terminal screens

### DIFF
--- a/clanki/tui/app.py
+++ b/clanki/tui/app.py
@@ -112,7 +112,6 @@ class ClankiApp(App[None]):
     .card-container {
         height: 1fr;
         min-height: 0;
-        margin-top: 1;
     }
 
     .card-content {

--- a/clanki/tui/app.py
+++ b/clanki/tui/app.py
@@ -121,12 +121,6 @@ class ClankiApp(App[None]):
         height: auto;
     }
 
-    .stats-bar {
-        height: 3;
-        background: $surface-darken-1;
-        padding: 0 1;
-    }
-
     .rating-bar {
         height: 3;
         background: $surface-darken-2;
@@ -151,7 +145,7 @@ class ClankiApp(App[None]):
     }
 
     .help-text {
-        height: 1;
+        height: auto;
         background: $surface-darken-1;
         text-align: center;
     }

--- a/clanki/tui/screens/review.py
+++ b/clanki/tui/screens/review.py
@@ -29,7 +29,7 @@ from ...config_store import load_config, save_config
 from ...render import render_html_to_text
 from ...review import CardView, DeckNotFoundError, Rating, ReviewSession, UndoError
 from ..widgets.card_view import CardViewWidget
-from ..widgets.stats_bar import DeckCountsBar, StatsBar
+from ..widgets.stats_bar import DeckCountsBar
 
 if TYPE_CHECKING:
     from ..app import ClankiApp
@@ -131,7 +131,6 @@ class ReviewScreen(Screen[None]):
                     id="deck-title",
                     markup=True,
                 ),
-                StatsBar(id="stats-bar"),
                 VerticalScroll(
                     CardViewWidget(
                         id="card-view",
@@ -157,7 +156,10 @@ class ReviewScreen(Screen[None]):
         return bool(self._current_card.question_audio)
 
     def _get_help_text(self) -> str:
-        """Get context-appropriate help text with action prompts."""
+        """Get context-appropriate help text with action prompts.
+
+        Collapses into two rows on narrow terminals so all hotkeys remain visible.
+        """
         state = self.clanki_app.state
         img_status = "on" if state.images_enabled else "off"
         snd_status = "on" if state.audio_enabled else "off"
@@ -172,14 +174,25 @@ class ReviewScreen(Screen[None]):
         if self._session is not None and self._session.can_undo:
             undo_hint = "[dim]u[/dim] undo  "
 
+        # Determine available width for single vs two-row layout
+        try:
+            width = self.size.width
+        except Exception:
+            width = 120
+        if width < 1:
+            width = 120
+
         if not self._answer_revealed:
             # Question side: Show Answer prompt
-            return (
-                "[bold reverse] Show Answer [/bold reverse] [dim](Space/Enter)[/dim]  "
+            primary = "[bold reverse] Show Answer [/bold reverse] [dim](Space/Enter)[/dim]"
+            secondary = (
                 f"{undo_hint}{replay_hint}"
                 f"[dim]s[/dim] snd:{snd_status}  [dim]i[/dim] img:{img_status}  "
                 "[dim]Esc[/dim] back"
             )
+            sep = "  " if width >= 80 else "\n"
+            return f"{primary}{sep}{secondary}"
+
         # Answer side: Rating bar with timestamps
         labels = (
             self._current_card.rating_labels
@@ -193,23 +206,36 @@ class ReviewScreen(Screen[None]):
 
         if labels:
             again, hard, good, easy = labels
-            return (
+            ratings = (
                 f"[bold red]1[/bold red] Again [dim]{again}[/dim]  "
                 f"[bold yellow]2[/bold yellow] Hard [dim]{hard}[/dim]  "
                 f"[bold green]3[/bold green] Good [dim]{good}[/dim]  "
-                f"[bold blue]4[/bold blue] Easy [dim]{easy}[/dim]  "
-                f"{extra_hints}"
+                f"[bold blue]4[/bold blue] Easy [dim]{easy}[/dim]"
             )
-        return (
-            "[bold red]1[/bold red] Again  "
-            "[bold yellow]2[/bold yellow] Hard  "
-            "[bold green]3[/bold green] Good  "
-            "[bold blue]4[/bold blue] Easy  "
-            f"{extra_hints}"
-        )
+        else:
+            ratings = (
+                "[bold red]1[/bold red] Again  "
+                "[bold yellow]2[/bold yellow] Hard  "
+                "[bold green]3[/bold green] Good  "
+                "[bold blue]4[/bold blue] Easy"
+            )
+
+        sep = "  " if width >= 90 else "\n"
+        return f"{ratings}{sep}{extra_hints}"
+
+    def on_resize(self) -> None:
+        """Update help bar layout when terminal is resized."""
+        try:
+            help_bar = self.query_one("#help-bar", Static)
+            help_bar.update(self._get_help_text())
+        except Exception:
+            pass
 
     async def on_mount(self) -> None:
         """Initialize review session and load first card."""
+        # Set terminal window/tab title to deck name
+        self._set_terminal_title(self._deck_name)
+
         col = self.clanki_app.state.col
         if col is None:
             self.notify("Collection not open", severity="error")
@@ -226,9 +252,21 @@ class ReviewScreen(Screen[None]):
         self._update_stats()
         await self._load_next_card()
 
+    @staticmethod
+    def _set_terminal_title(title: str) -> None:
+        """Set the terminal window/tab title via ANSI escape sequence."""
+        import sys
+
+        try:
+            sys.__stdout__.write(f"\033]0;{title}\007")
+            sys.__stdout__.flush()
+        except Exception:
+            pass
+
     def on_unmount(self) -> None:
-        """Stop audio when leaving the screen."""
+        """Stop audio and restore title when leaving the screen."""
         stop_audio()
+        self._set_terminal_title("Clanki")
 
     def _update_stats(self) -> None:
         """Update all stats displays with current counts."""
@@ -236,16 +274,6 @@ class ReviewScreen(Screen[None]):
             return
 
         counts = self._session.get_counts()
-
-        # Update top stats bar (session summary: due/reviewed)
-        stats_bar = self.query_one("#stats-bar", StatsBar)
-        stats_bar.update_counts(
-            new=counts.new_count,
-            learn=counts.learn_count,
-            review=counts.review_count,
-        )
-        session_stats = self.clanki_app.state.stats
-        stats_bar.update_session(reviewed=session_stats.reviewed)
 
         # Update bottom deck counts bar (new/learn/review)
         deck_counts_bar = self.query_one("#deck-counts-bar", DeckCountsBar)

--- a/clanki/tui/screens/review.py
+++ b/clanki/tui/screens/review.py
@@ -126,11 +126,6 @@ class ReviewScreen(Screen[None]):
         # Main content - centered with max-width
         yield Container(
             Vertical(
-                Static(
-                    f"[bold]{self._deck_name}[/bold]",
-                    id="deck-title",
-                    markup=True,
-                ),
                 VerticalScroll(
                     CardViewWidget(
                         id="card-view",
@@ -224,10 +219,15 @@ class ReviewScreen(Screen[None]):
         return f"{ratings}{sep}{extra_hints}"
 
     def on_resize(self) -> None:
-        """Update help bar layout when terminal is resized."""
+        """Update help bar layout and card compact mode when terminal is resized."""
         try:
             help_bar = self.query_one("#help-bar", Static)
             help_bar.update(self._get_help_text())
+        except Exception:
+            pass
+        try:
+            card_view = self.query_one("#card-view", CardViewWidget)
+            card_view._update_compact_mode()
         except Exception:
             pass
 
@@ -305,14 +305,12 @@ class ReviewScreen(Screen[None]):
         self._display_card()
 
     def _update_title_with_flag(self) -> None:
-        """Update the deck title Static to include a flag indicator if flagged."""
-        title = f"[bold]{self._deck_name}[/bold]"
+        """Update the terminal title to include a flag indicator if flagged."""
+        title = self._deck_name
         if self._current_flag > 0:
-            color = self.FLAG_COLORS.get(self._current_flag, "#ffffff")
             name = self.FLAG_NAMES.get(self._current_flag, "")
-            title += f"  [{color}]\u2691 {name}[/{color}]"
-        deck_title = self.query_one("#deck-title", Static)
-        deck_title.update(title)
+            title += f" \u2691 {name}"
+        self._set_terminal_title(title)
 
     def _display_card(self, play_audio: bool = True) -> None:
         """Display the current card content.

--- a/clanki/tui/widgets/card_view.py
+++ b/clanki/tui/widgets/card_view.py
@@ -42,6 +42,11 @@ class CardViewWidget(Vertical):
         height: auto;
     }
 
+    CardViewWidget.compact .card-section {
+        border: none;
+        padding: 0 1;
+    }
+
     CardViewWidget .content {
         height: auto;
     }
@@ -227,9 +232,18 @@ class CardViewWidget(Vertical):
             logger.warning("Styled rendering failed, using plain text: %s", exc)
             return [Static(html, classes="content")]
 
+    def _update_compact_mode(self) -> None:
+        """Toggle compact mode based on terminal width."""
+        try:
+            terminal_width = self.screen.size.width
+        except Exception:
+            terminal_width = 0
+        self.set_class(terminal_width <= 96, "compact")
+
     def _refresh_content(self) -> None:
         """Refresh the widget content."""
         try:
+            self._update_compact_mode()
             self.remove_children()  # Remove from self, not #card-content
 
             if self._answer_html is not None:
@@ -260,8 +274,12 @@ class CardViewWidget(Vertical):
 
         Uses a threshold of 4 columns to avoid feedback loops where
         small layout adjustments from image rendering trigger more resizes.
+        Toggles compact mode (no border/padding) on small viewports.
         """
         current_width = event.size.width
+
+        self._update_compact_mode()
+
         if abs(current_width - self._last_width) >= 4:
             self._last_width = current_width
             if self._images_enabled and (self._question_html or self._answer_html):


### PR DESCRIPTION
Removed session stats from deck review screen. 
Review/keybinding row collapses into multiple rows on smaller terminal widths. 
Displaying deck name in terminal title

Closes #7 